### PR TITLE
BE - completes patch helpoffer endpoint, and updates swagger

### DIFF
--- a/backend/__tests__/integration/v1/helpOffers/update.test.ts
+++ b/backend/__tests__/integration/v1/helpOffers/update.test.ts
@@ -1,0 +1,33 @@
+import request from "supertest";
+import app from "../../../../app/app";
+import db from "../../../../app/db/connection";
+
+import testData from "../../../../app/db/seeds/data/test";
+import seed from "../../../../app/db/seeds/seed";
+
+import { HelpOffer } from "../../../../app/db/seeds/data/types/data.types";
+
+beforeEach(async () => {
+    await seed(testData);
+});
+
+afterAll(async () => {
+    await db.end();
+});
+
+describe("update HelpOffer", () => {
+    test("200 - PATCH: Responds with an updated help offer status,", async () => {
+        const helpOfferBody: Partial<HelpOffer> = {
+            status: "accepted",
+            help_request_id: 2
+        };
+        const {
+            body: { updatedHelpOffer },
+        } = await request(app).patch("/api/users/10/help-offers").send(helpOfferBody).expect(200);
+        expect(updatedHelpOffer).toMatchObject({
+            helper_id: 10,
+            help_request_id: 2,
+            status: "accepted"
+        });
+    });
+});


### PR DESCRIPTION
PATCH api/users/:user_id/help-offers

Updates status of help offer using a user id and the composite id of the particular help offer. 

Returns updated help offer object in the format:

``json
{
"status: "active"
"helper_id: 1,
"help_request_id": 1
}
```